### PR TITLE
Use SSE intrinsic instead of f32::sqrt()

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - TARGET: 1.24.0-x86_64-pc-windows-msvc
+  - TARGET: 1.27.0-x86_64-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-msvc
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu


### PR DESCRIPTION
Can we assume that SSE is always present on x86?