### PR TITLE
Adding Copy, Clone, and Default impls for XInputState.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,7 @@ pub fn dynamic_load_xinput() -> Result<(), XInputLoadingFailure> {
 ///
 /// If you want to do something that the rust wrapper doesn't support, just use
 /// the raw field to get at the inner value.
+#[derive(Copy, Clone, Default)]
 pub struct XInputState {
   /// The raw value we're wrapping.
   pub raw: XINPUT_STATE,


### PR DESCRIPTION
Adding derived Copy, Clone, and Default impls for `XInputState`, so that downstream users who create wrappers around `XInputState` can also derive these.

These impls are mainly for convenience, as there is currently a somewhat tedious workaround.

```rust
#[derive(Copy, Clone, Default)]
struct DownstreamType(XINPUT_STATE);

impl DownstreamType {
  fn method_using_rusty_xinput_functionality(&mut self) {
    let mut x = rusty_xinput::XInputState { raw: self.0 };
    // do stuff with `x`
    self.0 = x.raw;
  }
}
```

However, with the addition of these new impls, downstream code doesn't need the workaround and can instead be more direct:

```rust
#[derive(Copy, Clone, Default)]
struct DownstreamType(rusty_xinput::XInputState);

impl DownstreamType {
  fn method_using_rusty_xinput_functionality(&mut self) {
    // do stuff with `self.0`
  }
}
```